### PR TITLE
Add Citizen NFT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Proof of Presence
 
 This is a collection of contracts aiming to implement tokenized timeshare access to land projects.
-You can read more about Closer in our [Documentation](https://closer.gitbook.io/closer-protocol/)
+You can read more about Closer in our [Documentation](https://closer.gitbook.io/documentation/)
 
 This contracts include:
 

--- a/deploy/007_deploy_citizen.ts
+++ b/deploy/007_deploy_citizen.ts
@@ -1,0 +1,46 @@
+import {HardhatRuntimeEnvironment} from 'hardhat/types';
+import {DeployFunction} from 'hardhat-deploy/types';
+import {ethers} from 'hardhat';
+import {TDFDiamond} from '../typechain';
+
+export const DEFAULT_CITIZEN_NAME = 'Citizen';
+export const DEFAULT_CITIZEN_SYMBOL = 'Citizen';
+export const DEFAULT_CITIZEN_BASE_URI = 'https://metadata.tdf.org/citizen/';
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const {deployments, getNamedAccounts} = hre;
+  const {deploy} = deployments;
+
+  const {deployer} = await getNamedAccounts();
+
+  const daoContract = (await ethers.getContract('TDFDiamond', deployer).catch(() => {
+    throw new Error('TDFDiamond contract not found. Please deploy it first.');
+  })) as TDFDiamond;
+
+  // For real deployment, Citizen uses different ProxyAdmin deployer/upgrader
+  // because of different EOA used for the deployment. The ProxyAdmin used for
+  // Citizen is under Citizen__DefaultProxyImplementation.json
+  await deploy('Citizen', {
+    from: deployer,
+    contract: 'Citizen',
+    proxy: {
+      proxyContract: 'OptimizedTransparentProxy',
+      owner: deployer, // Explicitly set the owner to the deployer
+      execute: {
+        init: {
+          methodName: 'initialize',
+          args: [
+            DEFAULT_CITIZEN_NAME,
+            DEFAULT_CITIZEN_SYMBOL,
+            DEFAULT_CITIZEN_BASE_URI,
+            daoContract.address,
+          ],
+        },
+      },
+    },
+    log: true,
+    autoMine: true,
+  });
+};
+export default func;
+func.tags = ['Citizen'];

--- a/hardhatExtensions/tasks.ts
+++ b/hardhatExtensions/tasks.ts
@@ -2,8 +2,9 @@ import {task} from 'hardhat/config';
 import {HardhatRuntimeEnvironment} from 'hardhat/types';
 import {ROLES} from '../utils';
 import {parseEther} from 'ethers/lib/utils';
+import {Citizen} from '../typechain';
 
-task('diamond:grant-role', 'set role to given address')
+task('diamond:grant-role', 'set role to given address in TDFDiamond')
   .addPositionalParam('address', 'address to assign the role')
   .addFlag('admin')
   .addFlag('minter')
@@ -49,6 +50,85 @@ task('diamond:mint', 'mint TDFtokens for')
     await diamond.mintCommunityTokenTo(address, parseEther(amount));
   });
 
+task('citizen:grant-role', 'set role to given address in Citizen contract')
+  .addPositionalParam('address', 'address to assign the role')
+  .addFlag('admin')
+  .addFlag('minter')
+  .addFlag('revoker')
+  .addFlag('upgrader')
+  .addFlag('dao')
+  .setAction(async ({address, admin, minter, revoker, upgrader, dao}, hre) => {
+    let role: string = ROLES.DEFAULT_ADMIN_ROLE;
+    let role_name = 'admin';
+    if (minter) {
+      role = ROLES.MINTER_ROLE;
+      role_name = 'minter';
+    }
+    if (revoker) {
+      role = ROLES.REVOKER_ROLE;
+      role_name = 'revoker';
+    }
+    if (upgrader) {
+      role = ROLES.UPGRADER_ROLE;
+      role_name = 'upgrader';
+    }
+    if (dao) {
+      role = ROLES.DAO_ROLE;
+      role_name = 'dao';
+    }
+
+    const citizen = await getCitizen(hre);
+    console.log(`granting role ${role_name} to ${address} in Citizen contract...`);
+    await citizen.grantRole(role, address);
+    console.log('ROLE GRANTED');
+  });
+
+task('citizen:mint', 'Mint a new Citizen NFT')
+  .addParam<string>('address', 'Destination address')
+  .addParam<string>('uri', 'Token URI for the citizen metadata')
+  .addParam<number>('level', 'Verification level (0-3)')
+  .setAction(async ({address, uri, level}, hre) => {
+    const citizen = await getCitizen(hre);
+    console.log(`Minting Citizen NFT to ${address} with verification level ${level}...`);
+    await citizen.safeMint(address, uri, level);
+    console.log('Citizen NFT minted successfully');
+  });
+
+task('citizen:revoke', 'Revoke citizenship from an address')
+  .addParam<string>('address', 'Address to revoke citizenship from')
+  .addParam<string>('reason', 'Reason for revocation')
+  .setAction(async ({address, reason}, hre) => {
+    const citizen = await getCitizen(hre);
+    console.log(`Revoking citizenship from ${address}...`);
+    await citizen.revokeCitizenship(address, reason);
+    console.log('Citizenship revoked successfully');
+  });
+
+task('citizen:update-level', 'Update verification level for a citizen')
+  .addParam<string>('address', 'Citizen address')
+  .addParam<number>('level', 'New verification level (0-3)')
+  .setAction(async ({address, level}, hre) => {
+    const citizen = await getCitizen(hre);
+    console.log(`Updating verification level for ${address} to ${level}...`);
+    await citizen.updateVerificationLevel(address, level);
+    console.log('Verification level updated successfully');
+  });
+
+task('citizen:info', 'Get citizenship information for an address')
+  .addParam<string>('address', 'Address to check')
+  .setAction(async ({address}, hre) => {
+    const citizen = await getCitizen(hre);
+    const isCitizen = await citizen.hasCitizenship(address);
+    console.log(`Is citizen: ${isCitizen}`);
+    
+    if (isCitizen) {
+      const info = await citizen.citizenshipInfo(address);
+      console.log(`Citizenship active: ${info.isActive}`);
+      console.log(`Citizenship since: ${new Date(info.since.toNumber() * 1000).toISOString()}`);
+      console.log(`Verification level: ${info.level}`);
+    }
+  });
+
 const getDiamond = async (hre: HardhatRuntimeEnvironment) => {
   const deployment = await hre.deployments.getOrNull('TDFDiamond');
   if (!deployment) throw new Error('Factory Not Deployed');
@@ -56,4 +136,13 @@ const getDiamond = async (hre: HardhatRuntimeEnvironment) => {
   return (await hre.ethers.getContractAt('TDFDiamond', deployment.address)).connect(
     await hre.ethers.getSigner(deployer)
   );
+};
+
+const getCitizen = async (hre: HardhatRuntimeEnvironment) => {
+  const deployment = await hre.deployments.getOrNull('Citizen');
+  if (!deployment) throw new Error('Citizen Not Deployed');
+  const {deployer} = await hre.getNamedAccounts();
+  return (await hre.ethers.getContractAt('Citizen', deployment.address)).connect(
+    await hre.ethers.getSigner(deployer)
+  ) as Citizen;
 };

--- a/src/ERC721/Citizen.sol
+++ b/src/ERC721/Citizen.sol
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721URIStorageUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
+
+/**
+ * @title Citizen
+ * @dev A soulbound ERC-721 token representing citizenship in the Traditional Dream Factory.
+ * This token cannot be transferred by users, only minted and revoked by authorized roles.
+ * It grants access to governance and utility functions within the TDF ecosystem.
+ */
+contract Citizen is 
+    Initializable, 
+    ERC721Upgradeable, 
+    ERC721URIStorageUpgradeable,
+    ERC721EnumerableUpgradeable,
+    AccessControlUpgradeable,
+    UUPSUpgradeable 
+{
+    using CountersUpgradeable for CountersUpgradeable.Counter;
+
+    // Role definitions
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 public constant REVOKER_ROLE = keccak256("REVOKER_ROLE");
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+    bytes32 public constant DAO_ROLE = keccak256("DAO_ROLE");
+    
+    // Token ID counter
+    CountersUpgradeable.Counter private _tokenIdCounter;
+    
+    // Base URI for metadata
+    string private _baseTokenURI;
+    
+    // Mapping to track if an address is a citizen
+    mapping(address => bool) public isCitizen;
+    
+    // Mapping to store citizenship issuance timestamps
+    mapping(address => uint256) public citizenshipTimestamp;
+    
+    // Mapping to store citizenship validation level (0=unverified, 1=basic, 2=enhanced, 3=full)
+    mapping(address => uint8) public verificationLevel;
+    
+    // Events
+    event CitizenshipGranted(address indexed citizen, uint256 tokenId, uint256 timestamp);
+    event CitizenshipRevoked(address indexed citizen, uint256 tokenId, uint256 timestamp, string reason);
+    event VerificationLevelChanged(address indexed citizen, uint8 oldLevel, uint8 newLevel);
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @dev Initializes the contract with required parameters
+     * @param name The name of the NFT collection
+     * @param symbol The symbol of the NFT collection
+     * @param baseURI The base URI for token metadata
+     * @param admin The address that will have admin rights (typically a DAO)
+     */
+    function initialize(
+        string memory name,
+        string memory symbol,
+        string memory baseURI,
+        address admin
+    ) initializer public {
+        __ERC721_init(name, symbol);
+        __ERC721URIStorage_init();
+        __ERC721Enumerable_init();
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+
+        _baseTokenURI = baseURI;
+        
+        // Setup roles
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(MINTER_ROLE, admin);
+        _grantRole(REVOKER_ROLE, admin);
+        _grantRole(UPGRADER_ROLE, admin);
+        _grantRole(DAO_ROLE, admin);
+    }
+
+    /**
+     * @dev Returns the base URI for token metadata
+     */
+    function _baseURI() internal view override returns (string memory) {
+        return _baseTokenURI;
+    }
+
+    /**
+     * @dev Sets a new base URI for all token metadata
+     * @param newBaseURI The new base URI to set
+     */
+    function setBaseURI(string memory newBaseURI) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        _baseTokenURI = newBaseURI;
+    }
+
+    /**
+     * @dev Mints a new Citizenship NFT to the specified address
+     * @param to The address that will receive the citizenship
+     * @param uri The token URI for this citizen's metadata
+     * @param level Initial verification level for the citizen
+     */
+    function safeMint(address to, string memory uri, uint8 level) public onlyRole(MINTER_ROLE) {
+        require(!isCitizen[to], "Citizen: Address is already a citizen");
+        require(level <= 3, "Citizen: Invalid verification level");
+
+        _tokenIdCounter.increment();
+        uint256 tokenId = _tokenIdCounter.current();
+        
+        _safeMint(to, tokenId);
+        _setTokenURI(tokenId, uri);
+        
+        isCitizen[to] = true;
+        citizenshipTimestamp[to] = block.timestamp;
+        verificationLevel[to] = level;
+        
+        emit CitizenshipGranted(to, tokenId, block.timestamp);
+    }
+
+    /**
+     * @dev Revokes citizenship from an address
+     * @param citizenAddress The address whose citizenship should be revoked
+     * @param reason The reason for citizenship revocation
+     */
+    function revokeCitizenship(address citizenAddress, string memory reason) public onlyRole(REVOKER_ROLE) {
+        require(isCitizen[citizenAddress], "Citizen: Address is not a citizen");
+        
+        uint256 tokenId = 0;
+        
+        // Find the token ID owned by this address
+        for (uint256 i = 1; i <= _tokenIdCounter.current(); i++) {
+            if (_exists(i) && ownerOf(i) == citizenAddress) {
+                tokenId = i;
+                break;
+            }
+        }
+        
+        require(tokenId != 0, "Citizen: No token found for this citizen");
+        
+        // Burn the token
+        _burn(tokenId);
+        
+        // Update state
+        isCitizen[citizenAddress] = false;
+        
+        emit CitizenshipRevoked(citizenAddress, tokenId, block.timestamp, reason);
+    }
+
+    /**
+     * @dev Updates the verification level for a citizen
+     * @param citizenAddress The address of the citizen
+     * @param newLevel The new verification level
+     */
+    function updateVerificationLevel(address citizenAddress, uint8 newLevel) public onlyRole(MINTER_ROLE) {
+        require(isCitizen[citizenAddress], "Citizen: Address is not a citizen");
+        require(newLevel <= 3, "Citizen: Invalid verification level");
+        
+        uint8 oldLevel = verificationLevel[citizenAddress];
+        verificationLevel[citizenAddress] = newLevel;
+        
+        emit VerificationLevelChanged(citizenAddress, oldLevel, newLevel);
+    }
+
+    /**
+     * @dev Returns whether an address has citizenship
+     * @param addressToCheck The address to check
+     * @return bool True if the address is a citizen
+     */
+    function hasCitizenship(address addressToCheck) public view returns (bool) {
+        return isCitizen[addressToCheck];
+    }
+
+    /**
+     * @dev Returns the citizenship information for an address
+     * @param citizenAddress The address to query
+     * @return isActive Whether the citizenship is active
+     * @return since The timestamp when citizenship was granted
+     * @return level The verification level of the citizen
+     */
+    function citizenshipInfo(address citizenAddress) public view returns (
+        bool isActive, 
+        uint256 since, 
+        uint8 level
+    ) {
+        return (
+            isCitizen[citizenAddress],
+            citizenshipTimestamp[citizenAddress],
+            verificationLevel[citizenAddress]
+        );
+    }
+
+    /**
+     * @dev Returns the total number of citizens
+     * @return uint256 The number of active citizenships
+     */
+    function totalCitizens() public view returns (uint256) {
+        return totalSupply();
+    }
+
+    /**
+     * @dev Overrides the transferFrom function to make tokens soulbound (non-transferable)
+     */
+    function transferFrom(address from, address to, uint256 tokenId) public override(ERC721Upgradeable) {
+        require(
+            hasRole(MINTER_ROLE, _msgSender()) || hasRole(REVOKER_ROLE, _msgSender()),
+            "Citizen: Citizenship tokens are soulbound and cannot be transferred"
+        );
+        super.transferFrom(from, to, tokenId);
+    }
+
+    /**
+     * @dev Overrides the safeTransferFrom function to make tokens soulbound (non-transferable)
+     */
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory data) public override(ERC721Upgradeable) {
+        require(
+            hasRole(MINTER_ROLE, _msgSender()) || hasRole(REVOKER_ROLE, _msgSender()),
+            "Citizen: Citizenship tokens are soulbound and cannot be transferred"
+        );
+        super.safeTransferFrom(from, to, tokenId, data);
+    }
+
+    /**
+     * @dev Required by the UUPSUpgradeable contract to restrict upgrade access
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+
+    /**
+     * @dev Resolves the inheritance conflict between multiple parent contracts
+     */
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal override(ERC721Upgradeable, ERC721EnumerableUpgradeable) {
+        super._beforeTokenTransfer(from, to, tokenId);
+    }
+
+    /**
+     * @dev Hook that is called before a set of consecutive token transfers.
+     */
+    function _beforeConsecutiveTokenTransfer(
+        address from,
+        address to,
+        uint256 first,
+        uint96 batchSize
+    ) internal virtual override(ERC721Upgradeable, ERC721EnumerableUpgradeable) {
+        super._beforeConsecutiveTokenTransfer(from, to, first, batchSize);
+    }
+
+    /**
+     * @dev Determines how token URIs are calculated
+     */
+    function tokenURI(uint256 tokenId) public view override(ERC721Upgradeable, ERC721URIStorageUpgradeable) returns (string memory) {
+        return super.tokenURI(tokenId);
+    }
+
+    /**
+     * @dev Burns a token and updates citizenship status
+     */
+    function _burn(uint256 tokenId) internal override(ERC721Upgradeable, ERC721URIStorageUpgradeable) {
+        address owner = ownerOf(tokenId);
+        super._burn(tokenId);
+        isCitizen[owner] = false;
+    }
+
+    /**
+     * @dev Required override for interface support
+     */
+    function supportsInterface(bytes4 interfaceId) public view override(
+        AccessControlUpgradeable, 
+        ERC721Upgradeable,
+        ERC721EnumerableUpgradeable
+    ) returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+}

--- a/src/Interfaces/ICitizen.sol
+++ b/src/Interfaces/ICitizen.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";
+
+/**
+ * @title ICitizen
+ * @dev Interface for the Citizen contract
+ */
+interface ICitizen is IERC721Upgradeable {
+    /**
+     * @dev Mints a new Citizenship NFT to the specified address
+     * @param to The address that will receive the citizenship
+     * @param uri The token URI for this citizen's metadata
+     * @param level Initial verification level for the citizen
+     */
+    function safeMint(address to, string memory uri, uint8 level) external;
+
+    /**
+     * @dev Revokes citizenship from an address
+     * @param citizenAddress The address whose citizenship should be revoked
+     * @param reason The reason for citizenship revocation
+     */
+    function revokeCitizenship(address citizenAddress, string memory reason) external;
+
+    /**
+     * @dev Updates the verification level for a citizen
+     * @param citizenAddress The address of the citizen
+     * @param newLevel The new verification level
+     */
+    function updateVerificationLevel(address citizenAddress, uint8 newLevel) external;
+
+    /**
+     * @dev Returns whether an address has citizenship
+     * @param addressToCheck The address to check
+     * @return bool True if the address is a citizen
+     */
+    function hasCitizenship(address addressToCheck) external view returns (bool);
+
+    /**
+     * @dev Returns the citizenship information for an address
+     * @param citizenAddress The address to query
+     * @return isActive Whether the citizenship is active
+     * @return since The timestamp when citizenship was granted
+     * @return level The verification level of the citizen
+     */
+    function citizenshipInfo(address citizenAddress) external view returns (
+        bool isActive, 
+        uint256 since, 
+        uint8 level
+    );
+
+    /**
+     * @dev Returns the total number of citizens
+     * @return uint256 The number of active citizenships
+     */
+    function totalCitizens() external view returns (uint256);
+
+    /**
+     * @dev Sets a new base URI for all token metadata
+     * @param newBaseURI The new base URI to set
+     */
+    function setBaseURI(string memory newBaseURI) external;
+}

--- a/test/Citizen.test.ts
+++ b/test/Citizen.test.ts
@@ -1,0 +1,201 @@
+import {expect} from 'chai';
+import {deployments, ethers} from 'hardhat';
+import {Citizen, TDFDiamond} from '../typechain';
+import {Address} from 'hardhat-deploy/types';
+import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/dist/src/signers';
+import {
+  DEFAULT_CITIZEN_NAME,
+  DEFAULT_CITIZEN_SYMBOL,
+  DEFAULT_CITIZEN_BASE_URI
+} from '../deploy/007_deploy_citizen';
+
+const setup = deployments.createFixture(async () => {
+  await deployments.fixture();
+  const [deployer, user, user2] = await ethers.getSigners();
+  const citizenContract = (await ethers.getContract('Citizen', deployer)) as Citizen;
+  const daoContract = (await ethers.getContract('TDFDiamond', deployer)) as TDFDiamond;
+
+  return {
+    deployer,
+    citizen: citizenContract,
+    daoContractAddress: daoContract.address,
+    user,
+    user2,
+  };
+});
+
+describe('Citizen Contract', function () {
+  let citizen: Citizen, owner: SignerWithAddress, dao: Address, user: SignerWithAddress, user2: SignerWithAddress;
+
+  beforeEach(async () => {
+    const testData = await setup();
+    owner = testData.deployer;
+    citizen = testData.citizen;
+    dao = testData.daoContractAddress;
+    user = testData.user;
+    user2 = testData.user2;
+  });
+
+  describe('Initialization', function () {
+    it('should have correct name, symbol, and base URI', async function () {
+      expect(await citizen.name()).to.equal(DEFAULT_CITIZEN_NAME);
+      expect(await citizen.symbol()).to.equal(DEFAULT_CITIZEN_SYMBOL);
+      // Base URI is private, so we can't directly check it
+    });
+  });
+
+  describe('Minting', function () {
+    it('should mint citizenship NFT successfully by account with MINTER_ROLE', async function () {
+      await citizen.connect(owner).safeMint(user.address, 'citizen-metadata-1.json', 1);
+      
+      expect(await citizen.balanceOf(user.address)).to.equal(1);
+      expect(await citizen.ownerOf(1)).to.equal(user.address);
+      expect(await citizen.tokenURI(1)).to.equal(`${DEFAULT_CITIZEN_BASE_URI}citizen-metadata-1.json`);
+      expect(await citizen.isCitizen(user.address)).to.be.true;
+      expect(await citizen.hasCitizenship(user.address)).to.be.true;
+      expect(await citizen.verificationLevel(user.address)).to.equal(1);
+      
+      const citizenInfo = await citizen.citizenshipInfo(user.address);
+      expect(citizenInfo.isActive).to.be.true;
+      expect(citizenInfo.level).to.equal(1);
+      // We can't predict the exact timestamp, but it should be set
+      expect(citizenInfo.since).to.be.gt(0);
+    });
+
+    it('should fail to mint if not authorized', async function () {
+      await expect(
+        citizen.connect(user).safeMint(user.address, 'citizen-metadata-1.json', 1)
+      ).to.be.revertedWith('AccessControl');
+    });
+
+    it('should fail to mint if address is already a citizen', async function () {
+      await citizen.connect(owner).safeMint(user.address, 'citizen-metadata-1.json', 1);
+      
+      await expect(
+        citizen.connect(owner).safeMint(user.address, 'citizen-metadata-2.json', 2)
+      ).to.be.revertedWith('Citizen: Address is already a citizen');
+    });
+
+    it('should fail to mint with invalid verification level', async function () {
+      await expect(
+        citizen.connect(owner).safeMint(user.address, 'citizen-metadata-1.json', 4)
+      ).to.be.revertedWith('Citizen: Invalid verification level');
+    });
+  });
+
+  describe('Citizenship Management', function () {
+    beforeEach(async () => {
+      await citizen.connect(owner).safeMint(user.address, 'citizen-metadata-1.json', 1);
+    });
+
+    it('should update verification level successfully', async function () {
+      await citizen.connect(owner).updateVerificationLevel(user.address, 2);
+      expect(await citizen.verificationLevel(user.address)).to.equal(2);
+      
+      const citizenInfo = await citizen.citizenshipInfo(user.address);
+      expect(citizenInfo.level).to.equal(2);
+    });
+
+    it('should fail to update verification level if not authorized', async function () {
+      await expect(
+        citizen.connect(user).updateVerificationLevel(user.address, 2)
+      ).to.be.revertedWith('AccessControl');
+    });
+
+    it('should fail to update verification level for non-citizen', async function () {
+      await expect(
+        citizen.connect(owner).updateVerificationLevel(user2.address, 2)
+      ).to.be.revertedWith('Citizen: Address is not a citizen');
+    });
+
+    it('should fail to update verification level with invalid level', async function () {
+      await expect(
+        citizen.connect(owner).updateVerificationLevel(user.address, 4)
+      ).to.be.revertedWith('Citizen: Invalid verification level');
+    });
+
+    it('should revoke citizenship successfully', async function () {
+      await citizen.connect(owner).revokeCitizenship(user.address, 'Violation of terms');
+      
+      expect(await citizen.isCitizen(user.address)).to.be.false;
+      expect(await citizen.hasCitizenship(user.address)).to.be.false;
+      
+      const citizenInfo = await citizen.citizenshipInfo(user.address);
+      expect(citizenInfo.isActive).to.be.false;
+      
+      // Token should be burned
+      await expect(citizen.ownerOf(1)).to.be.revertedWith('ERC721: invalid token ID');
+    });
+
+    it('should fail to revoke citizenship if not authorized', async function () {
+      await expect(
+        citizen.connect(user).revokeCitizenship(user.address, 'Violation of terms')
+      ).to.be.revertedWith('AccessControl');
+    });
+
+    it('should fail to revoke citizenship for non-citizen', async function () {
+      await expect(
+        citizen.connect(owner).revokeCitizenship(user2.address, 'Violation of terms')
+      ).to.be.revertedWith('Citizen: Address is not a citizen');
+    });
+  });
+
+  describe('Soulbound Token Behavior', function () {
+    beforeEach(async () => {
+      await citizen.connect(owner).safeMint(user.address, 'citizen-metadata-1.json', 1);
+    });
+
+    it('should not allow token transfers by regular users', async function () {
+      await expect(
+        citizen.connect(user).transferFrom(user.address, user2.address, 1)
+      ).to.be.revertedWith('Citizen: Citizenship tokens are soulbound and cannot be transferred');
+      
+      await expect(
+        citizen.connect(user).safeTransferFrom(user.address, user2.address, 1, '0x')
+      ).to.be.revertedWith('Citizen: Citizenship tokens are soulbound and cannot be transferred');
+    });
+
+    it('should allow token transfers by authorized roles', async function () {
+      // Owner has MINTER_ROLE by default
+      await citizen.connect(owner).transferFrom(user.address, user2.address, 1);
+      
+      expect(await citizen.ownerOf(1)).to.equal(user2.address);
+      expect(await citizen.isCitizen(user.address)).to.be.false;
+      expect(await citizen.isCitizen(user2.address)).to.be.true;
+    });
+  });
+
+  describe('Metadata Management', function () {
+    it('should set base URI successfully', async function () {
+      await citizen.connect(owner).safeMint(user.address, 'citizen-metadata-1.json', 1);
+      const initialTokenURI = await citizen.tokenURI(1);
+      
+      const newBaseURI = 'https://new-metadata.tdf.org/citizen/';
+      await citizen.connect(owner).setBaseURI(newBaseURI);
+      
+      expect(await citizen.tokenURI(1)).to.equal(`${newBaseURI}citizen-metadata-1.json`);
+      expect(await citizen.tokenURI(1)).to.not.equal(initialTokenURI);
+    });
+
+    it('should fail to set base URI if not authorized', async function () {
+      await expect(
+        citizen.connect(user).setBaseURI('https://new-metadata.tdf.org/citizen/')
+      ).to.be.revertedWith('AccessControl');
+    });
+  });
+
+  describe('Utility Functions', function () {
+    it('should return correct total citizens count', async function () {
+      expect(await citizen.totalCitizens()).to.equal(0);
+      
+      await citizen.connect(owner).safeMint(user.address, 'citizen-metadata-1.json', 1);
+      expect(await citizen.totalCitizens()).to.equal(1);
+      
+      await citizen.connect(owner).safeMint(user2.address, 'citizen-metadata-2.json', 2);
+      expect(await citizen.totalCitizens()).to.equal(2);
+      
+      await citizen.connect(owner).revokeCitizenship(user.address, 'Violation of terms');
+      expect(await citizen.totalCitizens()).to.equal(1);
+    });
+  });
+});

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -8,6 +8,10 @@ export const ROLES = {
   VAULT_MANAGER_ROLE: utils.keccak256(utils.toUtf8Bytes('VAULT_MANAGER_ROLE')),
   MEMBERSHIP_MANAGER_ROLE: utils.keccak256(utils.toUtf8Bytes('MEMBERSHIP_MANAGER_ROLE')),
   BOOKING_PLATFORM_ROLE: utils.keccak256(utils.toUtf8Bytes('BOOKING_PLATFORM_ROLE')),
+  // Citizen contract roles
+  REVOKER_ROLE: utils.keccak256(utils.toUtf8Bytes('REVOKER_ROLE')),
+  UPGRADER_ROLE: utils.keccak256(utils.toUtf8Bytes('UPGRADER_ROLE')),
+  DAO_ROLE: utils.keccak256(utils.toUtf8Bytes('DAO_ROLE')),
 } as const;
 
 export * from './Constants';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a non-transferable (soulbound) citizenship NFT with verification levels, role-based access control, and upgradeable governance.
  - Added Hardhat tasks for granting roles, minting, revoking, updating verification levels, and querying citizenship status.
  - Added a public interface for interacting with citizenship NFTs.

- **Deployment**
  - Added a deployment script to deploy the Citizen contract behind an upgradeable proxy.

- **Tests**
  - Added comprehensive tests for minting, revocation, verification updates, role enforcement, and soulbound behavior.

- **Chores**
  - Extended role constants to support new Citizen roles.

- **Documentation**
  - Updated README documentation link.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->